### PR TITLE
Configurable paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.patricio78</groupId>
     <artifactId>liquibase-kubernetes</artifactId>
-    <version>2.1.5</version>
+    <version>2.2.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Alternate Liquibase Locking solution which makes able an application to recover from a terminated Schema update using Kubernetes API.</description>


### PR DESCRIPTION
Kubernetes clusters might store Service Account CA bundle and token somewhere different than default location. Allow users to configure these paths via env vars, or use defaults if not defined.