### PR TITLE
Multiple vulnerability fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.patricio78</groupId>
     <artifactId>liquibase-kubernetes</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Alternate Liquibase Locking solution which makes able an application to recover from a terminated Schema update using Kubernetes API.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,17 +22,17 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>4.19.0</version>
+            <version>4.29.2</version>
         </dependency>
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
-            <version>18.0.0</version>
+            <version>21.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.6</version>
+            <version>2.0.16</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java
+++ b/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java
@@ -72,7 +72,7 @@ public class KubernetesConnector {
 
             CoreV1Api api = new CoreV1Api();
             LOG.info("Reading pod status, Pod name: {} Pod namespace: {}", podName, podNamespace);
-            V1Pod pod = api.readNamespacedPodStatus(podName, podNamespace, "true");
+            V1Pod pod = api.readNamespacedPodStatus(podName, podNamespace).pretty("true").execute();
             if (pod == null || pod.getStatus() == null) {
                 return false;
             }
@@ -112,7 +112,7 @@ public class KubernetesConnector {
             LOG.info("Reading pod status, Pod name: {} Pod namespace: {}", podName, podNamespace);
             V1Pod pod;
 
-            pod = api.readNamespacedPodStatus(podName, podNamespace, "true");
+            pod = api.readNamespacedPodStatus(podName, podNamespace).pretty("true").execute();
             if (pod == null || pod.getStatus() == null) {
                 return false;
             }


### PR DESCRIPTION
- Bump Java compile version to 17
- Update all 3 dependencies to their newest, non-vulnerable components (fixes for multiples transitive CVEs, such as CVE-2022-1471)
- Bump artifact version