### PR TITLE
fix: handle hostname (IP) LOCKEDBY format and widen exception handling

### DIFF
--- a/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java
+++ b/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java
@@ -80,7 +80,7 @@ public class KubernetesConnector {
             LOG.info("Pod phase: {}", podPhase);
             LOG.info("Connected to Kubernetes using fromCluster configuration");
             return true;
-        } catch (IOException | ApiException e) {
+        } catch (Exception e) {
             LOG.error("Connection fail to Kubernetes cluster using fromCluster configuration");
             LOG.error("Pod status read error", e);
             return false;
@@ -130,6 +130,10 @@ public class KubernetesConnector {
                 LOG.error("Can't find pod");
                 return false;
             }
+            LOG.error("Can't read Pod status: {}:{}", podNamespace, podName);
+            LOG.error("Pod status read error", e);
+            return false;
+        } catch (Exception e) {
             LOG.error("Can't read Pod status: {}:{}", podNamespace, podName);
             LOG.error("Pod status read error", e);
             return false;

--- a/src/main/java/liquibase/ext/KubernetesLockService.java
+++ b/src/main/java/liquibase/ext/KubernetesLockService.java
@@ -36,27 +36,36 @@ public class KubernetesLockService extends StandardLockService {
             String lockedBy = executor.queryForObject(new SelectFromDatabaseChangeLogLockStatement("LOCKEDBY"), String.class);
             if (StringUtils.isNotBlank(lockedBy)) {
                 LOG.info("Database locked by: {}", lockedBy);
+                String podNamespace = null;
+                String podName = null;
+
                 StringTokenizer tok = new StringTokenizer(lockedBy, ":");
                 if (tok.countTokens() == 2) {
-                    String podNamespace = tok.nextToken();
-                    String podName = tok.nextToken();
+                    podNamespace = tok.nextToken();
+                    podName = tok.nextToken();
+                } else if (lockedBy.contains(" (") && lockedBy.endsWith(")")) {
+                    podName = lockedBy.substring(0, lockedBy.indexOf(" ("));
+                    podNamespace = KubernetesConnector.getInstance().getPodNamespace();
+                }
+
+                if (podName != null && podNamespace != null) {
                     if (KubernetesConnector.getInstance().isCurrentPod(podNamespace, podName)) {
                         LOG.info("Lock created by the same pod, release lock");
                         releaseLock();
-                    }
-                    boolean lockHolderPodActive = KubernetesConnector.getInstance().isPodActive(podNamespace, podName);
-                    if (!lockHolderPodActive) {
+                    } else if (!KubernetesConnector.getInstance().isPodActive(podNamespace, podName)) {
                         LOG.info("Lock created by an inactive pod, release lock");
                         releaseLock();
                     }
                 } else {
-                    LOG.info("Can't parse LOCKEDBY field: {}", lockedBy);
+                    LOG.warn("Can't parse LOCKEDBY field: {}", lockedBy);
                 }
             } else {
-                LOG.info("Databased is not locked");
+                LOG.info("Database is not locked");
             }
         } catch (DatabaseException e) {
             LOG.error("Can't read the LOCKEDBY field from databasechangeloglock", e);
+        } catch (Exception e) {
+            LOG.error("Error checking lock status", e);
         }
         super.waitForLock();
     }


### PR DESCRIPTION
## Problem

[KubernetesLockService.waitForLock()](cci:1://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/liquibase/ext/KubernetesLockService.java:31:4-70:5) only parses `LOCKEDBY` in `namespace:podname` format. When [KubernetesConnector.connect()](cci:1://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java:50:4-87:5) fails and Liquibase falls back to `StandardLockService`, the lock is written as `hostname (IP)` (via `InetAddress.getLocalHost()`). On next pod start, [KubernetesLockService](cci:2://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/liquibase/ext/KubernetesLockService.java:17:0-71:1) can't parse this format (line 52: "Can't parse LOCKEDBY field") and takes no action — the orphaned lock persists indefinitely, causing an infinite crash loop.

Additionally, [KubernetesConnector.connect()](cci:1://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java:50:4-87:5) only catches `IOException | ApiException`. Runtime exceptions (e.g., `IllegalArgumentException` from K8s client encountering unknown API fields) crash the [InstanceHolder](cci:2://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java:31:4-33:5) static initializer, causing `NoClassDefFoundError` on all subsequent [getInstance()](cci:1://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java:35:4-37:5) calls.

## Changes

**[KubernetesLockService.java](cci:7://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/liquibase/ext/KubernetesLockService.java:0:0-0:0)**
- Parse both `namespace:podname` and `hostname (IP)` LOCKEDBY formats
- For `hostname (IP)`: extract hostname as pod name (hostname = pod name in K8s), use current pod's namespace
- Use `else if` to skip redundant [isPodActive()](cci:1://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java:108:4-140:5) call after self-lock release
- Add `catch (Exception)` to prevent uncaught runtime exceptions from blocking lock recovery
- Upgrade unparseable format log from INFO to WARN
- Fix "Databased" typo

**[KubernetesConnector.java](cci:7://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java:0:0-0:0)**
- [connect()](cci:1://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java:50:4-87:5): widen catch from `IOException | ApiException` to `Exception` — prevents static initializer crash from runtime exceptions
- [isPodActive()](cci:1://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/com/github/patricio78/liquibase/kubernetes/KubernetesConnector.java:108:4-140:5): add `catch (Exception)` — prevents runtime exceptions from blocking lock release

## Backward Compatibility

All changes are strictly backward compatible:
- Existing `namespace:podname` flow is unchanged
- `hostname (IP)` handling is additive — previously broken, now works
- Unknown formats still fall through to [super.waitForLock()](cci:1://file:///Users/anarayangupta/Desktop/MS-Phoenix/sagas-core/liquibase-kubernetes/src/main/java/liquibase/ext/KubernetesLockService.java:31:4-70:5) (same as before, but logged at WARN)
- Widened catches: all previously caught exceptions still caught, additional ones now handled gracefully
- No API changes, no new dependencies, no config changes

## Impact Without Fix

Production-critical service stuck in CrashLoopBackOff for 4+ hours. Only recovery was manual DB intervention:
```sql
UPDATE databasechangeloglock SET locked=false, lockedby=NULL, lockgranted=NULL WHERE id=1;